### PR TITLE
try single section for dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-version: 2
-updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "jGaboardi"
+  
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "jGaboardi"


### PR DESCRIPTION
Following #58, this PR tries a single section for `dependabot.yml` that doesn't overwrite the `github-actions` section.