### PR TITLE
add default ascending sort param

### DIFF
--- a/nhgisxwalk/geocrosswalk.py
+++ b/nhgisxwalk/geocrosswalk.py
@@ -14,7 +14,12 @@ id_generator_funcs = [blk_gj, bgp_gj, bkg_gj, trt_gj, cty_gj]
 id_generators = {f.__name__: f for f in id_generator_funcs}
 
 # sorting parameters -- all crosswalks are sorted accordingly
-sort_params = {"na_position": "last", "ignore_index": True, "inplace": True}
+sort_params = {
+    "ascending": True,
+    "na_position": "last",
+    "ignore_index": True,
+    "inplace": True,
+}
 
 CSV = "csv"
 


### PR DESCRIPTION
This PR adds the default `ascending` parameter in [`sort_params`](https://github.com/jGaboardi/nhgisxwalk/blob/master/nhgisxwalk/geocrosswalk.py#L17) for use in [`pandas.DataFrame.sort_values()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_values.html).