### PR TITLE
minor correction for extract_unique_stfips()

### DIFF
--- a/nhgisxwalk/geocrosswalk.py
+++ b/nhgisxwalk/geocrosswalk.py
@@ -794,7 +794,7 @@ def extract_unique_stfips(cls=None, df=None, endpoint="target", code="gj"):
     Returns
     -------
     
-    unique_stfips : 
+    unique_stfips : set
         All unique states from the specified column.
     
     """


### PR DESCRIPTION
The PR provides a minor correction for the docstring of the `nhgisxwalk.extract_unique_stfips()` function.